### PR TITLE
Add HomeScreen and plugin routers

### DIFF
--- a/backend/src/api.js
+++ b/backend/src/api.js
@@ -1,4 +1,7 @@
 import { Router } from 'express';
+import lmStudioRouter from './lmStudio.js';
+import ragRouter from './rag.js';
+import mcpRouter from './mcp.js';
 
 const router = Router();
 const reports = [];
@@ -32,9 +35,8 @@ router.get('/reports', (req, res) => {
   res.json(filtered);
 });
 
-// Placeholder for LM Studio, RAG plugins, and external mCP servers
-router.use('/plugins', (req, res) => {
-  res.json({ message: 'Plugin endpoint placeholder' });
-});
+router.use('/lm', lmStudioRouter);
+router.use('/rag', ragRouter);
+router.use('/mcp', mcpRouter);
 
 export default router;

--- a/backend/src/lmStudio.js
+++ b/backend/src/lmStudio.js
@@ -1,0 +1,10 @@
+import { Router } from 'express';
+
+const router = Router();
+
+router.post('/prompt', (req, res) => {
+  // Placeholder for LM Studio integration
+  res.json({ message: 'LM Studio response placeholder' });
+});
+
+export default router;

--- a/backend/src/mcp.js
+++ b/backend/src/mcp.js
@@ -1,0 +1,10 @@
+import { Router } from 'express';
+
+const router = Router();
+
+router.post('/send', (req, res) => {
+  // Placeholder for external mCP server integration
+  res.json({ message: 'mCP server placeholder' });
+});
+
+export default router;

--- a/backend/src/rag.js
+++ b/backend/src/rag.js
@@ -1,0 +1,10 @@
+import { Router } from 'express';
+
+const router = Router();
+
+router.get('/', (req, res) => {
+  // Placeholder for RAG plugin endpoint
+  res.json({ message: 'RAG plugin placeholder' });
+});
+
+export default router;

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,13 +1,6 @@
 import React from 'react';
-import { View, Text, Button } from 'react-native';
+import HomeScreen from './HomeScreen.js';
 
 export default function App() {
-  return (
-    <View className="flex-1 items-center justify-center p-4">
-      <Text className="text-xl font-bold mb-4">ICE-WATCH</Text>
-      {/* Map component using Mapbox or Leaflet fallback */}
-      <View className="h-64 w-full bg-gray-200 mb-4" />
-      <Button title="Report ICE Activity" onPress={() => {}} />
-    </View>
-  );
+  return <HomeScreen />;
 }

--- a/frontend/src/HomeScreen.js
+++ b/frontend/src/HomeScreen.js
@@ -1,0 +1,81 @@
+import React, { useState } from 'react';
+import {
+  View,
+  Text,
+  Button,
+  Modal,
+  TextInput,
+  TouchableOpacity,
+  FlatList,
+} from 'react-native';
+
+const dummyReports = [
+  { id: 1, lat: 40.7128, lon: -74.006, description: 'ICE sighting near park' },
+  { id: 2, lat: 40.7138, lon: -74.001, description: 'Checkpoint at subway' },
+];
+
+export default function HomeScreen() {
+  const [modalVisible, setModalVisible] = useState(false);
+  const [description, setDescription] = useState('');
+
+  const handleSubmit = () => {
+    // Placeholder submit logic
+    setModalVisible(false);
+    setDescription('');
+  };
+
+  return (
+    <View className="flex-1">
+      {/* Mapbox MapView placeholder */}
+      <View className="flex-1 bg-gray-200 items-center justify-center">
+        <Text className="text-gray-500">Map goes here</Text>
+      </View>
+
+      {/* Report pins list placeholder */}
+      <FlatList
+        data={dummyReports}
+        keyExtractor={(item) => item.id.toString()}
+        renderItem={({ item }) => (
+          <Text className="p-2 text-center">
+            {item.description} ({item.lat}, {item.lon})
+          </Text>
+        )}
+      />
+
+      <View className="p-4">
+        <Button
+          title="Report ICE Activity"
+          onPress={() => setModalVisible(true)}
+        />
+      </View>
+
+      <Modal
+        visible={modalVisible}
+        animationType="slide"
+        onRequestClose={() => setModalVisible(false)}
+      >
+        <View className="flex-1 justify-center p-4 bg-white">
+          <Text className="text-lg font-bold mb-4">New Report</Text>
+          <TextInput
+            className="border p-2 mb-4"
+            placeholder="Description"
+            value={description}
+            onChangeText={setDescription}
+          />
+          {/* Image picker placeholder */}
+          <View className="h-32 bg-gray-100 mb-4 items-center justify-center">
+            <Text className="text-gray-500">Image picker</Text>
+          </View>
+          {/* Geolocation placeholder */}
+          <Text className="mb-4">Location: 40.7128, -74.0060</Text>
+          <TouchableOpacity
+            className="bg-blue-500 p-3 rounded"
+            onPress={handleSubmit}
+          >
+            <Text className="text-white text-center">Submit</Text>
+          </TouchableOpacity>
+        </View>
+      </Modal>
+    </View>
+  );
+}


### PR DESCRIPTION
## Summary
- create `HomeScreen` with map placeholder, report modal, and dummy pins
- make `HomeScreen` default app screen
- expand Express API with modular routers for LM Studio, RAG plugins and mCP

## Testing
- `npx prettier --write frontend/src/HomeScreen.js frontend/src/App.js backend/src/api.js backend/src/lmStudio.js backend/src/rag.js backend/src/mcp.js`
- `node -e "require('./backend/server.js')" &`
- `curl -X POST http://localhost:3000/api/lm/prompt -d '{}' -H 'Content-Type: application/json'`
- `curl http://localhost:3000/api/rag`
- `curl -X POST http://localhost:3000/api/mcp/send -d '{}' -H 'Content-Type: application/json'`


------
https://chatgpt.com/codex/tasks/task_e_688b720df29483329679d770654f3931